### PR TITLE
fix fluent-plugin-kubernetes_metadata_filter auto install fluentd1.2.3 and entry point syntax error

### DIFF
--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && gem install aws-sdk-core -v 2.10.50 \
     && gem install pfpt-fluent-plugin-cloudwatch-logs -v 0.4.5 \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
-    && gem install fluent-plugin-kubernetes_metadata_filter \
+    && gem install fluent-plugin-kubernetes_metadata_filter -v 1.1.0 \
     && gem install ffi \
     && gem install fluent-plugin-systemd -v 0.0.8 \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v0.12/debian-cloudwatch/entrypoint.sh
+++ b/docker-image/v0.12/debian-cloudwatch/entrypoint.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-if [[ -z ${FLUENT_ELASTICSEARCH_USER} ]] ; then
+if [ -z ${FLUENT_ELASTICSEARCH_USER} ] ; then
    sed -i  '/FLUENT_ELASTICSEARCH_USER/d' /fluentd/etc/${FLUENTD_CONF}
 fi
 
-if [[ -z ${FLUENT_ELASTICSEARCH_PASSWORD} ]] ; then
+if [ -z ${FLUENT_ELASTICSEARCH_PASSWORD} ] ; then
    sed -i  '/FLUENT_ELASTICSEARCH_PASSWORD/d' /fluentd/etc/${FLUENTD_CONF}
 fi
 


### PR DESCRIPTION
fix fluent-plugin-kubernetes_metadata_filter auto install fluentd1.2.3 by specify a specific version
entrypoint.sh has a syntax error