### PR TITLE
change dockerfile to run cmd instead of using entrypoint.sh

### DIFF
--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -54,4 +54,4 @@ ENV FLUENTD_CONF="fluent.conf"
 #ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 
 # Run Fluentd
-CMD ["/fluentd/entrypoint.sh"]
+CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins ${FLUENTD_OPT}


### PR DESCRIPTION
Kubernetes 1.9.4 onward has a change that configmap, etc will be read only, where the entrypoint.sh is doing a sed, so instead of having entrypoint.sh which we does not use elasticsearch in this case, use CMD in dockerfile.